### PR TITLE
Add debug scroll logging

### DIFF
--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -142,6 +142,10 @@ recording_options:
       - auto
       - evdev
       - pynput
+  enable_mouse_listener:
+    value: true
+    type: bool
+    description: "Enable capturing mouse button events. Disable if you experience issues when scrolling."
   recording_mode:
     value: press_to_toggle
     type: str
@@ -301,3 +305,7 @@ misc:
     value: false
     type: bool
     description: "Automatically pause/resume media during recording"
+  log_input_events:
+    value: false
+    type: bool
+    description: "Write all input events to 'input_debug.log' for troubleshooting."


### PR DESCRIPTION
## Summary
- allow disabling mouse listening via `enable_mouse_listener`
- add `log_input_events` option and helper logger
- log key and mouse events when enabled

## Testing
- `pytest -q`
- `flake8` *(fails: E302, E501, F401, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6840057fb8a4832ea177337c0b0d66c7