### PR TITLE
Retry transcription on failure

### DIFF
--- a/src/result_thread.py
+++ b/src/result_thread.py
@@ -5,6 +5,8 @@ import sounddevice as sd
 import tempfile
 import wave
 import webrtcvad
+import os
+import soundfile as sf
 from PyQt5.QtCore import QThread, QMutex, pyqtSignal
 from collections import deque
 from threading import Event
@@ -96,13 +98,30 @@ class ResultThread(QThread):
             self.statusSignal.emit('transcribing', self.use_llm)
             ConfigManager.console_print('Transcribing...')
 
-            # Time the transcription process
-            start_time = time.time()
-            result = transcribe(audio_data, self.local_model)
-            end_time = time.time()
+            result = ''
+            attempts = 3
+            for attempt in range(1, attempts + 1):
+                start_time = time.time()
+                result = transcribe(audio_data, self.local_model)
+                end_time = time.time()
 
-            transcription_time = end_time - start_time
-            ConfigManager.console_print(f'Transcription completed in {transcription_time:.2f} seconds. Post-processed line: {result}')
+                transcription_time = end_time - start_time
+                if result:
+                    ConfigManager.console_print(
+                        f'Transcription completed in {transcription_time:.2f} seconds on attempt {attempt}. Post-processed line: {result}'
+                    )
+                    break
+                ConfigManager.console_print(
+                    f'Transcription attempt {attempt} failed after {transcription_time:.2f} seconds.'
+                )
+
+            if not result:
+                file_path = self._save_failed_audio(audio_data)
+                ConfigManager.console_print(
+                    f'All {attempts} transcription attempts failed. Audio saved to: {file_path}'
+                )
+                self.statusSignal.emit('transcription_failed', self.use_llm)
+                return
 
             if not self.is_running:
                 return
@@ -125,6 +144,19 @@ class ResultThread(QThread):
             self.resultSignal.emit('')
         finally:
             self.is_transcribing = False  # Ensure flag is reset
+
+    def _save_failed_audio(self, audio_data):
+        """Save failed audio to a FLAC file for later retry."""
+        try:
+            save_dir = os.path.join(os.path.expanduser('~'), '.whisperwriter', 'failed_audio')
+            os.makedirs(save_dir, exist_ok=True)
+            timestamp = time.strftime('%Y%m%d-%H%M%S')
+            file_path = os.path.join(save_dir, f'failed_{timestamp}.flac')
+            sf.write(file_path, audio_data, self.sample_rate, format='FLAC')
+            return file_path
+        except Exception as e:
+            ConfigManager.console_print(f'Failed to save audio: {e}')
+            return ''
 
     def _record_audio(self):
         """

--- a/src/ui/status_window.py
+++ b/src/ui/status_window.py
@@ -197,6 +197,17 @@ class StatusWindow(BaseWindow):
             self.icon_label.setPixmap(self.pencil_pixmap)
             self.status_label.setText('Transcribing...')
             self.shortcuts_label.hide()
+
+        elif status == 'transcription_failed':
+            self.icon_label.setPixmap(self.pencil_pixmap)
+            self.status_label.setText('Transcription Failed - Audio Saved')
+            self.status_label.setStyleSheet('color: white;')
+            self.setStyleSheet(
+                "background-color: #cc3333; border: 1px solid #ffaaaa; border-radius: 5px;"
+            )
+            self.shortcuts_label.hide()
+            QTimer.singleShot(3000, self.close)
+            self.show()
             
         elif status == 'processing_llm_cleanup':
             self.icon_label.setPixmap(self.pencil_pixmap)


### PR DESCRIPTION
## Summary
- retry transcription up to three times when using the transcription thread
- save failed audio as FLAC if all retries fail
- show a red failure bubble when transcription fails

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849222b63c8832e92b10e47dcc4c6fb