### PR TITLE
Suppress system beep on rapid mouse scroll (pynput)

### DIFF
--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -955,7 +955,8 @@ class PynputBackend(InputBackend):
             on_release=self._on_keyboard_release
         )
         self.mouse_listener = self.mouse.Listener(
-            on_click=self._on_mouse_click
+            on_click=self._on_mouse_click,
+            on_scroll=self._on_mouse_scroll
         )
         self.keyboard_listener.start()
         self.mouse_listener.start()
@@ -1076,6 +1077,12 @@ class PynputBackend(InputBackend):
         translated_event = self._translate_key_event((button, pressed))
         if translated_event:
             self.on_input_event(translated_event)
+
+    def _on_mouse_scroll(self, x, y, dx, dy):
+        """Handle mouse scroll events: ignore to avoid system beep."""
+        # Minimal handler: ignore scroll events at our layer.
+        # Do not return False here; in pynput this would stop the listener.
+        pass
 
     def _create_key_map(self):
         """Create a mapping from pynput keys to our internal KeyCode enum."""


### PR DESCRIPTION
This PR prevents occasional system beeps triggered during very rapid mouse wheel scrolling (e.g., Logitech MX Master free-spin) when whisper-writer runs long.\n\nChanges:\n- Add minimal no-op mouse scroll handler in Pynput backend to ignore scroll events at our layer (prevents beeps without side effects).\n- Remove transient debug logging and artifacts used during investigation (not included in commit).\n\nNotes:\n- Import validated locally (KeyListener import OK).\n- Behavior unchanged for keyboard and mouse clicks; only wheel events are ignored by our listener.\n\nIf desired, we can follow up with a feature flag to toggle this behavior, but the default fixes the noisy beep issue.