### PR TITLE
Fix Azure responses routing and UI automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ The first time you open the app, if a configuration file doesn't exist, a Settin
 
 #### LLM Post-processing Options
 - `enabled`: Set to `true` to enable LLM post-processing. (Default: `false`)
-- `api_type`: The LLM API to use for post-processing. (Default: `chatgpt`)
-  - `chatgpt`: Use OpenAI's ChatGPT API.
+- `api_type`: The LLM API to use for post-processing. (Default: `openai`)
+  - `openai`: Use OpenAI's API.
   - `claude`: Use Anthropic's Claude API.
   - `gemini`: Use Google's Gemini API.
   - `groq`: Use Groq's LLM service.

--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -240,11 +240,11 @@ llm_post_processing:
     description: "Enable post-processing of transcribed text through an LLM API"
   
   api_type:
-    value: chatgpt
+    value: openai
     type: str
     description: "The LLM API to use for post-processing. If Ollama is selected, local LLM processing will be used. Ollama must be installed separately."
     options:
-      - chatgpt
+      - openai
       - azure_openai
       - claude
       - gemini
@@ -275,6 +275,16 @@ llm_post_processing:
     value: null
     type: str
     description: "Deployment name for Azure OpenAI LLM model"
+    
+  azure_openai_llm_cleanup_deployment_name:
+    value: "gpt-4.1"
+    type: str
+    description: "Deployment name for the cleanup model when using Azure OpenAI"
+    
+  azure_openai_llm_instruction_deployment_name:
+    value: "gpt-4.1"
+    type: str
+    description: "Deployment name for the instruction model when using Azure OpenAI"
     
   azure_openai_llm_api_version:
     value: "2024-02-01"

--- a/src/llm_processor.py
+++ b/src/llm_processor.py
@@ -54,6 +54,14 @@ class LLMProcessor:
                 self.api_type = 'claude'  # Only use claude as last resort fallback
         else:
             self.api_type = api_type
+
+        if self.api_type == 'chatgpt':
+            ConfigManager.console_print("Deprecated api_type 'chatgpt' detected, treating as 'openai'")
+            self.api_type = 'openai'
+            try:
+                ConfigManager.set_config_value('openai', 'llm_post_processing', 'api_type')
+            except Exception:
+                pass
         
         ConfigManager.console_print(f"Initializing LLM Processor with API type: {self.api_type}")
         

--- a/tests/test_azure_end_to_end.py
+++ b/tests/test_azure_end_to_end.py
@@ -267,7 +267,7 @@ def test_azure_openai_provider_switching():
     providers = [
         {
             'name': 'ChatGPT',
-            'api_type': 'chatgpt',
+            'api_type': 'openai',
             'required_fields': ['openai_api_key']
         },
         {

--- a/tests/test_azure_ui_integration.py
+++ b/tests/test_azure_ui_integration.py
@@ -9,8 +9,9 @@ def test_settings_window_azure_llm_provider_options():
     
     # Test the provider options mapping
     provider_fields = {
-        'chatgpt': ['openai_api_key'],
-        'azure_openai': ['azure_openai_llm_api_key', 'azure_openai_llm_endpoint', 
+        'openai': ['openai_api_key'],
+        'azure_openai': ['azure_openai_llm_api_key', 'azure_openai_llm_endpoint',
+                       'azure_openai_llm_cleanup_deployment_name', 'azure_openai_llm_instruction_deployment_name',
                        'azure_openai_llm_deployment_name', 'azure_openai_llm_api_version'],
         'claude': ['claude_api_key'],
         'gemini': ['gemini_api_key'],
@@ -23,6 +24,8 @@ def test_settings_window_azure_llm_provider_options():
     expected_fields = [
         'azure_openai_llm_api_key', 
         'azure_openai_llm_endpoint',
+        'azure_openai_llm_cleanup_deployment_name',
+        'azure_openai_llm_instruction_deployment_name',
         'azure_openai_llm_deployment_name', 
         'azure_openai_llm_api_version'
     ]
@@ -131,6 +134,8 @@ def test_config_schema_azure_openai_llm_fields():
                 'azure_openai_llm_endpoint': {'type': 'str'},
                 'azure_openai_llm_api_version': {'type': 'str'},
                 'azure_openai_llm_deployment_name': {'type': 'str'},
+                'azure_openai_llm_cleanup_deployment_name': {'type': 'str'},
+                'azure_openai_llm_instruction_deployment_name': {'type': 'str'},
                 'azure_openai_llm_api_key': {'type': 'str'}
             }
         }
@@ -154,6 +159,8 @@ def test_config_schema_azure_openai_llm_fields():
             'azure_openai_llm_endpoint',
             'azure_openai_llm_api_version', 
             'azure_openai_llm_deployment_name',
+            'azure_openai_llm_cleanup_deployment_name',
+            'azure_openai_llm_instruction_deployment_name',
             'azure_openai_llm_api_key'
         ]
         
@@ -168,13 +175,35 @@ def test_config_schema_azure_openai_llm_fields():
     required_azure_fields = [
         'azure_openai_llm_api_key',
         'azure_openai_llm_endpoint',
-        'azure_openai_llm_deployment_name', 
+        'azure_openai_llm_deployment_name',
+        'azure_openai_llm_cleanup_deployment_name',
+        'azure_openai_llm_instruction_deployment_name',
         'azure_openai_llm_api_version'
     ]
     
     for field in required_azure_fields:
         assert field in llm_section, f"Missing Azure OpenAI LLM field in schema: {field}"
         assert llm_section[field]['type'] == 'str', f"Field {field} should be string type"
+
+def test_settings_window_combobox_value_helper_prefers_data():
+    from ui.settings_window import SettingsWindow
+
+    class DummyCombo:
+        def __init__(self, data, text):
+            self._data = data
+            self._text = text
+
+        def currentData(self):
+            return self._data
+
+        def currentText(self):
+            return self._text
+
+    with_data = DummyCombo('openai', 'OpenAI API')
+    without_data = DummyCombo(None, 'Azure OpenAI')
+
+    assert SettingsWindow._get_combobox_value(with_data) == 'openai'
+    assert SettingsWindow._get_combobox_value(without_data) == 'Azure OpenAI'
 
 def test_settings_window_toggle_function_logic():
     """Test the logic of provider toggle functions."""
@@ -183,8 +212,9 @@ def test_settings_window_toggle_function_logic():
     def simulate_toggle_llm_provider_options(provider):
         """Simulate the settings window toggle function logic."""
         provider_fields = {
-            'chatgpt': ['openai_api_key'],
-            'azure_openai': ['azure_openai_llm_api_key', 'azure_openai_llm_endpoint', 
+            'openai': ['openai_api_key'],
+            'azure_openai': ['azure_openai_llm_api_key', 'azure_openai_llm_endpoint',
+                           'azure_openai_llm_cleanup_deployment_name', 'azure_openai_llm_instruction_deployment_name',
                            'azure_openai_llm_deployment_name', 'azure_openai_llm_api_version'],
             'claude': ['claude_api_key'],
             'gemini': ['gemini_api_key'],
@@ -213,6 +243,8 @@ def test_settings_window_toggle_function_logic():
     azure_fields = [
         'azure_openai_llm_api_key', 
         'azure_openai_llm_endpoint',
+        'azure_openai_llm_cleanup_deployment_name',
+        'azure_openai_llm_instruction_deployment_name',
         'azure_openai_llm_deployment_name', 
         'azure_openai_llm_api_version'
     ]

--- a/tests/test_llm_processor_migration.py
+++ b/tests/test_llm_processor_migration.py
@@ -1,0 +1,29 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def patched_dependencies(monkeypatch):
+    sys.path.insert(0, 'src')
+    from llm_processor import ConfigManager, KeyringManager
+
+    monkeypatch.setattr(ConfigManager, 'get_config_section', lambda section: {
+        'api_type': 'chatgpt',
+        'enabled': True,
+        'temperature': 0.1,
+        'endpoint': 'https://example.com'
+    })
+    monkeypatch.setattr(ConfigManager, 'console_print', lambda *args, **kwargs: None)
+    monkeypatch.setattr(ConfigManager, 'get_schema', lambda: {'llm_post_processing': {}})
+    monkeypatch.setattr(ConfigManager, 'set_config_value', lambda *args, **kwargs: None, raising=False)
+    monkeypatch.setattr(KeyringManager, 'get_api_key', lambda *_: 'dummy-key')
+    return None
+
+
+def test_chatgpt_api_type_is_migrated_to_openai(patched_dependencies):
+    from llm_processor import LLMProcessor
+
+    processor = LLMProcessor(api_type='chatgpt')
+    assert processor.api_type == 'openai'
+

--- a/tests/test_ui_behavior.py
+++ b/tests/test_ui_behavior.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication, QComboBox, QWidget
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _set_combobox_value(combo: QComboBox, value: str):
+    index = combo.findData(value)
+    if index == -1:
+        index = combo.findText(value)
+    assert index != -1, f"Value {value} not found in combo {combo.objectName()}"
+    combo.setCurrentIndex(index)
+
+
+@pytest.fixture
+def settings_window(monkeypatch, qapp):
+    sys.path.insert(0, 'src')
+    from ui.settings_window import SettingsWindow, LLMProcessor
+
+    monkeypatch.setattr(SettingsWindow, "get_available_sound_devices", lambda self: [])
+    monkeypatch.setattr(LLMProcessor, "get_available_models", lambda self, api: ['gpt-5.1', 'gpt-4.1'])
+
+    window = SettingsWindow()
+    window.show()
+    qapp.processEvents()
+    yield window
+    window.close()
+
+
+def test_temperature_visibility_toggles(settings_window, qapp):
+    api_combo = settings_window.findChild(QComboBox, 'llm_post_processing_api_type_input')
+    _set_combobox_value(api_combo, 'openai')
+    qapp.processEvents()
+
+    cleanup_combo = settings_window.cleanup_model_combo
+    instruction_combo = settings_window.instruction_model_combo
+    assert cleanup_combo and instruction_combo
+
+    cleanup_combo.setCurrentText('gpt-5.1')
+    instruction_combo.setCurrentText('gpt-5.1')
+    settings_window.update_temperature_visibility()
+    qapp.processEvents()
+    assert settings_window._should_hide_temperature() is True
+
+    cleanup_combo.setCurrentText('gpt-4.1')
+    instruction_combo.setCurrentText('gpt-4.1')
+    settings_window.update_temperature_visibility()
+    qapp.processEvents()
+    assert settings_window._should_hide_temperature() is False
+
+
+def test_azure_fields_visible(settings_window, qapp):
+    api_combo = settings_window.findChild(QComboBox, 'llm_post_processing_api_type_input')
+    _set_combobox_value(api_combo, 'azure_openai')
+    qapp.processEvents()
+
+    field_names = [
+        'azure_openai_llm_cleanup_deployment_name',
+        'azure_openai_llm_instruction_deployment_name',
+        'azure_openai_llm_deployment_name',
+        'azure_openai_llm_api_version'
+    ]
+
+    for name in field_names:
+        widget = settings_window.findChild(QWidget, f'llm_post_processing_{name}_input')
+        assert widget is not None and not widget.isHidden(), f"{name} should be visible"
+


### PR DESCRIPTION
## Summary
- add backwards-compatible support for legacy `chatgpt` api_type values by migrating them to `openai`
- update Azure/OpenAI UI to expose cleanup/instruction deployment names, hide temperature for reasoning models, and rename the provider to "OpenAI API"
- switch Azure reasoning models to use the official Responses endpoint (`/openai/v1/responses`) and add headless UI tests to verify the dropdown behavior

## Testing
- `python -m pytest tests/test_llm_processor_migration.py -v`
- `python -m pytest tests/test_ui_behavior.py -v`
- `python -m pytest tests/ -v`
