### PR TITLE
Logging improvements and Azure transcription defaults

### DIFF
--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -370,3 +370,7 @@ misc:
     value: false
     type: bool
     description: "Enable verbose logging including full prompts, system messages, and API responses"
+  log_cleanup_prompt:
+    value: false
+    type: bool
+    description: "When verbose logging is enabled, include cleanup system prompts in logs"

--- a/src/llm_processor.py
+++ b/src/llm_processor.py
@@ -107,7 +107,10 @@ class LLMProcessor:
             schema = ConfigManager.get_schema().get('llm_post_processing', {})
             default_cleanup = (schema.get('system_prompt') or {}).get('value')
             system_message = default_cleanup or ""
-            ConfigManager.console_print(f"Using default system message: {system_message}", verbose=True)
+            if ConfigManager.should_log_cleanup_prompt():
+                ConfigManager.console_print(f"Using default system message: {system_message}", verbose=True)
+            else:
+                ConfigManager.console_print("Using default cleanup system message", verbose=True)
         
         api_type = self.config['api_type']
         
@@ -142,7 +145,10 @@ class LLMProcessor:
             ConfigManager.console_print(f"No model specified, using default {mode} model for {api_type}: {model}")
         
         self._safe_console_print(f"Processing text with {api_type} using {mode} model: {model}")
-        self._safe_console_print(f"Using system message: {system_message}", verbose=True)
+        if mode == "cleanup" and not ConfigManager.should_log_cleanup_prompt():
+            self._safe_console_print("Using cleanup system message (logging disabled)", verbose=True)
+        else:
+            self._safe_console_print(f"Using system message: {system_message}", verbose=True)
         
         if api_type == 'claude':
             return self._process_claude(text, system_message, model)

--- a/src/llm_processor.py
+++ b/src/llm_processor.py
@@ -144,7 +144,16 @@ class LLMProcessor:
                 model = default_models.get(api_type)
             ConfigManager.console_print(f"No model specified, using default {mode} model for {api_type}: {model}")
         
-        self._safe_console_print(f"Processing text with {api_type} using {mode} model: {model}")
+        azure_deployment = None
+        if api_type == 'azure_openai':
+            azure_deployment = self._get_azure_deployment_name(mode)
+
+        if api_type == 'azure_openai' and azure_deployment:
+            self._safe_console_print(
+                f"Processing text with {api_type} using {mode} deployment: {azure_deployment} (model setting: {model})"
+            )
+        else:
+            self._safe_console_print(f"Processing text with {api_type} using {mode} model: {model}")
         if mode == "cleanup" and not ConfigManager.should_log_cleanup_prompt():
             self._safe_console_print("Using cleanup system message (logging disabled)", verbose=True)
         else:
@@ -579,6 +588,7 @@ class LLMProcessor:
         if not deployment_name:
             ConfigManager.console_print("Azure OpenAI LLM deployment name not configured")
             return text
+        ConfigManager.console_print(f"Using Azure OpenAI LLM deployment: {deployment_name}")
         headers = {
             'api-key': api_key,
             'Content-Type': 'application/json'

--- a/src/main.py
+++ b/src/main.py
@@ -235,8 +235,12 @@ class WhisperWriterApp(QObject):
                     
                     # Start with a clean system message
                     system_message = base_message.strip() if base_message else ""
+                    log_cleanup_prompt = ConfigManager.should_log_cleanup_prompt()
                     
-                    ConfigManager.console_print(f"Retrieved {mode_name} base message from settings: {system_message}", verbose=True)
+                    if mode_name == "cleanup" and not log_cleanup_prompt:
+                        ConfigManager.console_print("Retrieved cleanup base message from settings", verbose=True)
+                    else:
+                        ConfigManager.console_print(f"Retrieved {mode_name} base message from settings: {system_message}", verbose=True)
                     
                     if not file_path:
                         ConfigManager.console_print("No file path set, using only the system message from settings")
@@ -261,7 +265,10 @@ class WhisperWriterApp(QObject):
                         ConfigManager.console_print("Warning: No system message found, using original transcription")
                         return result
                     
-                    ConfigManager.console_print(f"Final system message being sent to LLM: {system_message}", verbose=True)
+                    if mode_name == "cleanup" and not log_cleanup_prompt:
+                        ConfigManager.console_print("Final cleanup system message prepared for LLM", verbose=True)
+                    else:
+                        ConfigManager.console_print(f"Final system message being sent to LLM: {system_message}", verbose=True)
                     processed_result = self.llm_processor.process_text(result, system_message)
                     if processed_result:
                         result = processed_result.strip()
@@ -324,8 +331,12 @@ class WhisperWriterApp(QObject):
             
             # Start with a clean system message
             system_message = base_message.strip() if base_message else ""
+            log_cleanup_prompt = ConfigManager.should_log_cleanup_prompt()
             
-            ConfigManager.console_print(f"Base cleanup system message: {system_message}", verbose=True)
+            if log_cleanup_prompt:
+                ConfigManager.console_print(f"Base cleanup system message: {system_message}", verbose=True)
+            else:
+                ConfigManager.console_print("Base cleanup system message retrieved", verbose=True)
             
             # Append file contents if file path exists and is not empty
             if file_path and os.path.exists(file_path):
@@ -346,7 +357,10 @@ class WhisperWriterApp(QObject):
                 ConfigManager.console_print("Warning: No cleanup system message found")
                 return
             
-            ConfigManager.console_print(f"Final cleanup system message: {system_message}", verbose=True)
+            if log_cleanup_prompt:
+                ConfigManager.console_print(f"Final cleanup system message: {system_message}", verbose=True)
+            else:
+                ConfigManager.console_print("Final cleanup system message prepared", verbose=True)
             
             # Run through LLM cleanup
             cleaned_text = self.llm_processor.process_text(clipboard_text, system_message)

--- a/src/main.py
+++ b/src/main.py
@@ -269,18 +269,34 @@ class WhisperWriterApp(QObject):
                         ConfigManager.console_print("Final cleanup system message prepared for LLM", verbose=True)
                     else:
                         ConfigManager.console_print(f"Final system message being sent to LLM: {system_message}", verbose=True)
+                    original_result = result
                     processed_result = self.llm_processor.process_text(result, system_message)
+                    if processed_result is not None:
+                        ConfigManager.console_print(f"Cleanup raw output: {processed_result}", verbose=True)
                     if processed_result:
                         result = processed_result.strip()
+                        if result == original_result:
+                            ConfigManager.console_print("Cleanup output matches original transcription", verbose=True)
+                        else:
+                            ConfigManager.console_print("Cleanup output differs from original transcription", verbose=True)
                     else:
-                        ConfigManager.console_print("LLM processing failed, using original transcription")
+                        ConfigManager.console_print("LLM processing failed or returned empty output, using original transcription")
+                        result = original_result
                     
                 except Exception as e:
                     ConfigManager.console_print(f"Error processing text through LLM: {str(e)}")
                     return result
 
             # Type the result
-            self.input_simulator.typewrite(result)
+            typed_result = False
+            try:
+                ConfigManager.console_print(f"Typing transcription result length: {len(result)}", verbose=True)
+                self.input_simulator.typewrite(result)
+                typed_result = True
+            except Exception as e:
+                ConfigManager.console_print(f"Error typing transcription result: {str(e)}")
+            finally:
+                ConfigManager.console_print(f"Typed transcription result: {typed_result}", verbose=True)
             
             if ConfigManager.get_config_value('misc', 'noise_on_completion'):
                 AudioPlayer(os.path.join('assets', 'beep.wav')).play(block=True)
@@ -364,8 +380,10 @@ class WhisperWriterApp(QObject):
             
             # Run through LLM cleanup
             cleaned_text = self.llm_processor.process_text(clipboard_text, system_message)
+            ConfigManager.console_print(f"Cleanup output (clipboard): {cleaned_text}", verbose=True)
             
             if cleaned_text and cleaned_text != clipboard_text:
+                paste_succeeded = False
                 try:
                     # Simulate keyboard events with proper cleanup
                     keyboard = Controller()
@@ -385,6 +403,8 @@ class WhisperWriterApp(QObject):
                         with keyboard.pressed(Key.ctrl):
                             keyboard.press('v')
                             keyboard.release('v')
+
+                        paste_succeeded = True
                         
                         if ConfigManager.get_config_value('misc', 'noise_on_completion'):
                             AudioPlayer(os.path.join('assets', 'beep.wav')).play(block=True)
@@ -411,8 +431,11 @@ class WhisperWriterApp(QObject):
                     
                 except Exception as e:
                     ConfigManager.console_print(f"Error simulating keyboard: {str(e)}")
+                finally:
+                    ConfigManager.console_print(f"Pasted cleaned clipboard text: {paste_succeeded}", verbose=True)
             else:
                 ConfigManager.console_print("Text unchanged after LLM processing")
+                ConfigManager.console_print("Cleanup output empty or unchanged; no paste performed", verbose=True)
             
         except Exception as e:
             ConfigManager.console_print(f"Error cleaning text: {str(e)}")

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -362,6 +362,7 @@ def transcribe_with_azure_openai(audio_data, api_options):
         if not deployment_name:
             ConfigManager.console_print("Azure OpenAI deployment name not configured")
             return ''
+        ConfigManager.console_print(f"Using Azure OpenAI deployment: {deployment_name}")
             
         # Construct Azure OpenAI URL  
         base_url = f"{endpoint.rstrip('/')}/openai/deployments/{deployment_name}/audio/transcriptions"
@@ -391,7 +392,9 @@ def transcribe_with_azure_openai(audio_data, api_options):
             'api-version': api_version
         }
         
-        ConfigManager.console_print(f"Sending request to Azure OpenAI API using {model}...")
+        ConfigManager.console_print(
+            f"Sending request to Azure OpenAI API using deployment {deployment_name} with model parameter {model}..."
+        )
         response = requests.post(
             base_url,
             headers={'api-key': api_key},  # Simplified headers for Azure OpenAI

--- a/src/utils.py
+++ b/src/utils.py
@@ -231,6 +231,16 @@ class ConfigManager:
         return cls._instance.config.get('misc', {}).get('verbose_mode', False)
 
     @classmethod
+    def should_log_cleanup_prompt(cls):
+        """Return True when cleanup prompt logging is enabled for this session."""
+        if cls._instance is None:
+            return False
+        config = cls._instance.config.get('misc', {})
+        if not config.get('verbose_mode', False):
+            return False
+        return config.get('log_cleanup_prompt', False)
+
+    @classmethod
     def reload_logging(cls):
         """Reload logging configuration after config changes."""
         cls._setup_logging()


### PR DESCRIPTION
## Summary
- add `log_cleanup_prompt` to control cleanup prompt logging under verbose mode
- add detailed logs for cleanup outputs and typing/paste success
- log Azure transcription/LLM deployment names and update Azure transcription defaults for gpt-4o-transcribe

## Testing
- C:/whisper-writer/venv/Scripts/python.exe -m pytest tests/ -v