### PR TITLE
Add GPT-5.4 support with reasoning effort none

### DIFF
--- a/src/ui/settings_window.py
+++ b/src/ui/settings_window.py
@@ -406,6 +406,7 @@ class SettingsWindow(BaseWindow):
     def _default_llm_model_choices():
         """Return a curated list of OpenAI model IDs for quick selection."""
         return [
+            'gpt-5.4',
             'gpt-5.3-chat-latest',
             'gpt-5.2',
             'gpt-5.1',

--- a/tests/test_llm_cleanup_safeguards.py
+++ b/tests/test_llm_cleanup_safeguards.py
@@ -29,11 +29,12 @@ def test_cleanup_rejection_reason_allows_small_edit():
     sys.path.pop(0)
 
 
-def test_reasoning_effort_prefers_medium_for_gpt53_chat():
+def test_reasoning_effort_uses_expected_defaults_for_gpt5_variants():
     sys.path.insert(0, 'src')
     from llm_processor import LLMProcessor
 
     assert LLMProcessor._get_preferred_reasoning_effort('gpt-5.3-chat-latest') == 'medium'
+    assert LLMProcessor._get_preferred_reasoning_effort('gpt-5.4') == 'none'
     assert LLMProcessor._get_preferred_reasoning_effort('gpt-5.1') == 'none'
 
     sys.path.pop(0)

--- a/tests/test_ui_behavior.py
+++ b/tests/test_ui_behavior.py
@@ -60,6 +60,15 @@ def test_temperature_visibility_toggles(settings_window, qapp):
     assert settings_window._should_hide_temperature() is False
 
 
+def test_default_llm_model_choices_include_gpt54():
+    sys.path.insert(0, 'src')
+    from ui.settings_window import SettingsWindow
+
+    assert 'gpt-5.4' in SettingsWindow._default_llm_model_choices()
+
+    sys.path.pop(0)
+
+
 def test_azure_fields_visible(settings_window, qapp):
     api_combo = settings_window.findChild(QComboBox, 'llm_post_processing_api_type_input')
     _set_combobox_value(api_combo, 'azure_openai')


### PR DESCRIPTION
## Summary
- add `gpt-5.4` to the default OpenAI model choices in settings
- keep `reasoning.effort` set to `none` for `gpt-5.4`
- preserve the existing `gpt-5.3-chat-*` special case using `medium`
- add regression coverage for both reasoning defaults and UI model availability

## Testing
- `c:/whisper-writer/venv/Scripts/python.exe -m pytest tests/test_llm_cleanup_safeguards.py tests/test_ui_behavior.py -v`
- `c:/whisper-writer/venv/Scripts/python.exe -m pytest tests/ -v`